### PR TITLE
Support .heic images on file upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-.nyc_output
-coverage
 *.swp
 package-lock.json
 test/public/modules/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.nyc_output
+coverage
 *.swp
 package-lock.json
 test/public/modules/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.109.0 (2020-06-18)
+
+* Add [heic-to-jpeg-middleware](https://github.com/boutell/heic-to-jpeg-middleware) to support uploading `heic/heif` images (the standard format for recent iPhones/iPads).
+
 ## 2.108.0 (2020-06-07)
 
 * UX improvement: if a piece type has the `contextual: true` option set and workflow is present, do not default published to `false`. There is already a good opportunity to review before the public sees the piece afforded by workflow.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 2.107.1 (2020-05-29)
+## 2.108.0 (2020-05-29)
 
+* If called with a scalar argument, `apos.utils.clonePermanent` now returns scalars (strings, booleans, numbers) as-is. This makes it easier to use the method when the argument might or might not be an object that requires cloning.
 * The `distinctCounts` feature (also known as `counts: true` for `piecesFilters`) is now compatible with the `apostrophe-db-mongo-3-driver` module, when in use. Note that there is little benefit to that module now that `emulate-mongo-2-driver` is standard in Apostrophe and employs the MongoDB 3.x driver under the hood but provides a 2.x-compatible API. However those who strongly prefer the 3.x driver APIs for direct MongoDB queries may use `apostrophe-db-mongo-3-driver` with more confidence given this fix.
 
 ## 2.107.0 (2020-05-20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * If called with a scalar argument, `apos.utils.clonePermanent` now returns scalars (strings, booleans, numbers) as-is. This makes it easier to use the method when the argument might or might not be an object that requires cloning.
 
+## 2.107.2 (2020-06-10)
+
+* Fixed a regression that caused difficulty saving array fields with `color` subfields in their schema. This regression was introduced in 2.107.0.
+
 ## 2.107.1 (2020-06-03)
 
 * The `distinctCounts` feature (also known as `counts: true` for `piecesFilters`) is now compatible with the `apostrophe-db-mongo-3-driver` module, when in use. Note that there is little benefit to that module now that `emulate-mongo-2-driver` is standard in Apostrophe and employs the MongoDB 3.x driver under the hood but provides a 2.x-compatible API. However those who strongly prefer the 3.x driver APIs for direct MongoDB queries may use `apostrophe-db-mongo-3-driver` with more confidence given this fix.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.108.0 (2020-06-09)
+
+* UX improvement: if a piece type has the `contextual: true` option set and workflow is present, do not default published to `false`. There is already a good opportunity to review before the public sees the piece afforded by workflow.
+
 ## 2.107.1 (2020-06-03)
 
 * The `distinctCounts` feature (also known as `counts: true` for `piecesFilters`) is now compatible with the `apostrophe-db-mongo-3-driver` module, when in use. Note that there is little benefit to that module now that `emulate-mongo-2-driver` is standard in Apostrophe and employs the MongoDB 3.x driver under the hood but provides a 2.x-compatible API. However those who strongly prefer the 3.x driver APIs for direct MongoDB queries may use `apostrophe-db-mongo-3-driver` with more confidence given this fix.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.107.1 (2020-05-29)
+
+* The `distinctCounts` feature (also known as `counts: true` for `piecesFilters`) is now compatible with the `apostrophe-db-mongo-3-driver` module, when in use. Note that there is little benefit to that module now that `emulate-mongo-2-driver` is standard in Apostrophe and employs the MongoDB 3.x driver under the hood but provides a 2.x-compatible API. However those who strongly prefer the 3.x driver APIs for direct MongoDB queries may use `apostrophe-db-mongo-3-driver` with more confidence given this fix.
+
 ## 2.107.0 (2020-05-20)
 
 * CKEditor has been updated to version 4.14, addressing a low-risk XSRF vulnerability. The vulnerability required that the source code editor feature be activated and that a user with editing privileges be convinced to import specially crafted markup, which is unlikely in practice.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.107.1 (2020-05-29)
+## 2.107.1 (2020-06-03)
 
 * The `distinctCounts` feature (also known as `counts: true` for `piecesFilters`) is now compatible with the `apostrophe-db-mongo-3-driver` module, when in use. Note that there is little benefit to that module now that `emulate-mongo-2-driver` is standard in Apostrophe and employs the MongoDB 3.x driver under the hood but provides a 2.x-compatible API. However those who strongly prefer the 3.x driver APIs for direct MongoDB queries may use `apostrophe-db-mongo-3-driver` with more confidence given this fix.
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2016, 2017, 2018, 2019 Apostrophe Technologies
+Copyright (c) 2016, 2017, 2018, 2019, 2020 Apostrophe Technologies
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/lib/modules/apostrophe-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-areas/public/js/editor.js
@@ -898,7 +898,7 @@ apos.define('apostrophe-areas-editor', {
     };
 
     // This is a wrapper for $.onSafe that avoids events that are actually
-    // happening in nested areas. -Tom and Sam
+    // happening in nested areas.
 
     self.on = function(eventType, selector, fn) {
       if (arguments.length === 2) {

--- a/lib/modules/apostrophe-attachments/lib/routes.js
+++ b/lib/modules/apostrophe-attachments/lib/routes.js
@@ -2,26 +2,30 @@ var _ = require('@sailshq/lodash');
 
 module.exports = function(self, options) {
 
-  self.apiRoute('post', 'upload', self.middleware.canUpload, self.apos.middleware.files, function(req, res, next) {
-    // Must use text/plain for file upload responses in IE <= 9,
-    // doesn't hurt in other browsers. -Tom
-    res.header("Content-Type", "text/plain");
-    // The name attribute could be anything because of how fileupload
-    // controls work; we don't really care.
-    var file = _.values(req.files || {})[0];
-    if (!file) {
-      return next('notfound');
-    }
-    return self.accept(req, file, function(err, file) {
-      if (err) {
-        return next(err);
+  self.apiRoute('post', 'upload',
+    self.middleware.canUpload,
+    self.apos.middleware.files,
+    self.apos.middleware.heicImages,
+    function(req, res, next) {
+      // Must use text/plain for file upload responses in IE <= 9,
+      // doesn't hurt in other browsers. -Tom
+      res.header("Content-Type", "text/plain");
+      // The name attribute could be anything because of how fileupload
+      // controls work; we don't really care.
+      var file = _.values(req.files || {})[0];
+      if (!file) {
+        return next('notfound');
       }
-      if (req.query.html) {
-        res.setHeader('Content-Type', 'text/html');
-      }
-      return next(null, { file: file });
+      return self.accept(req, file, function(err, file) {
+        if (err) {
+          return next(err);
+        }
+        if (req.query.html) {
+          res.setHeader('Content-Type', 'text/html');
+        }
+        return next(null, { file: file });
+      });
     });
-  });
 
   // Crop a previously uploaded image, based on the `id` POST parameter
   // and the `crop` POST parameter. `id` should refer to an existing

--- a/lib/modules/apostrophe-browser-utils/public/js/lean.js
+++ b/lib/modules/apostrophe-browser-utils/public/js/lean.js
@@ -182,6 +182,11 @@
       var responseHeader = this.getResponseHeader("Content-Type");
       var trimResponse = this.responseText.trim();
       var data;
+      if (!responseHeader) {
+        // Can happen, usually when the response body is null and
+        // Express sees no reason to set a content type
+        return callback(error(), this.responseText);
+      }
       if (responseHeader.match(/^application\/json/)) {
         // Definitely JSON, treat as such
         try {

--- a/lib/modules/apostrophe-db/index.js
+++ b/lib/modules/apostrophe-db/index.js
@@ -150,9 +150,8 @@ module.exports = {
 
     // Query the server status every 10 seconds just to prevent
     // the mongodb module version 2.1.19+ or better from allowing
-    // the connection to time out... with no error messages or clues
-    // that we need to reconnect it... because apparently that's
-    // a feature now. -Tom
+    // the connection to time out. That module provides no error messages or clues
+    // that we need to reconnect it.
 
     self.keepalive = function() {
       self.keepaliveCollection = self.apos.db.collection('aposKeepalive');

--- a/lib/modules/apostrophe-docs/lib/cursor.js
+++ b/lib/modules/apostrophe-docs/lib/cursor.js
@@ -988,16 +988,32 @@ module.exports = {
               }
             }
           ]);
+          console.log(self.db);
           return self.db.aggregate(pipeline, function(err, results) {
             if (err) {
               return callback(err);
             }
-            var counts = {};
-            _.each(results, function(doc) {
-              counts[doc._id] = doc.count;
-            });
-            self.set('distinctCounts', counts);
-            return callback(null, _.pluck(results, '_id'));
+            console.log('**', results);
+            if (results.toArray) {
+              // from apostrophe-db-mongo-3-driver
+              return results.toArray(function(err, results) {
+                if (err) {
+                  return callback(err);
+                }
+                return handleResults(results);
+              });
+            } else {
+              // from the 2.x driver or our compatibility wrapper
+              return handleResults(results);
+            }
+            function handleResults() {
+              var counts = {};
+              _.each(results, function(doc) {
+                counts[doc._id] = doc.count;
+              });
+              self.set('distinctCounts', counts);
+              return callback(null, _.pluck(results, '_id'));
+            }
           });
         }
       }

--- a/lib/modules/apostrophe-docs/lib/cursor.js
+++ b/lib/modules/apostrophe-docs/lib/cursor.js
@@ -988,12 +988,10 @@ module.exports = {
               }
             }
           ]);
-          console.log(self.db);
           return self.db.aggregate(pipeline, function(err, results) {
             if (err) {
               return callback(err);
             }
-            console.log('**', results);
             if (results.toArray) {
               // from apostrophe-db-mongo-3-driver
               return results.toArray(function(err, results) {
@@ -1006,7 +1004,7 @@ module.exports = {
               // from the 2.x driver or our compatibility wrapper
               return handleResults(results);
             }
-            function handleResults() {
+            function handleResults(results) {
               var counts = {};
               _.each(results, function(doc) {
                 counts[doc._id] = doc.count;

--- a/lib/modules/apostrophe-express/index.js
+++ b/lib/modules/apostrophe-express/index.js
@@ -564,7 +564,8 @@ module.exports = {
       // every route but is recommended for use in your own
       // routes when needful
       self.apos.middleware = {
-        files: require('connect-multiparty')()
+        files: require('connect-multiparty')(),
+        heicImages: require('heic-to-jpeg-middleware')()
       };
     };
 

--- a/lib/modules/apostrophe-pages/lib/pagesCursor.js
+++ b/lib/modules/apostrophe-pages/lib/pagesCursor.js
@@ -226,7 +226,7 @@ module.exports = {
     // For instance, if you have thousands of subpages
     // of a "blog" page, you might want to hide them from
     // the global reorganize interface by setting their
-    // reorganize property to false. —Tom and Sam
+    // reorganize property to false.
 
     self.addFilter('reorganize', {
       def: null,

--- a/lib/modules/apostrophe-pieces/index.js
+++ b/lib/modules/apostrophe-pieces/index.js
@@ -68,7 +68,10 @@ module.exports = {
           type: 'boolean',
           name: 'published',
           label: 'Published',
-          def: false
+          // Patched later with a final ruling of true or false
+          // if it is not overridden at project level, see
+          // patchPublished method
+          def: 'contextual'
         }
       ].concat(options.addFields || []);
     }
@@ -266,6 +269,21 @@ module.exports = {
     if (self.options.piecesFilters) {
       self.apos.utils.warnDev('⚠️ The piecesFilters option was passed to ' + self.__meta.name + ', which\nextends apostrophe-pieces. This option should be passed to the corresponding\nmodule that extends apostrophe-pieces-pages.');
     }
-  }
 
+    self.on('apostrophe:modulesReady', 'patchPublished', function() {
+      var published = _.find(self.schema, { name: 'published' });
+      if (!published) {
+        return;
+      }
+      if (published.def !== 'contextual') {
+        return;
+      }
+      var workflow = self.apos.modules['apostrophe-workflow'];
+      if (workflow && workflow.includeType(self.name)) {
+        published.def = true;
+      } else {
+        published.def = false;
+      }
+    });
+  }
 };

--- a/lib/modules/apostrophe-schemas/public/js/user.js
+++ b/lib/modules/apostrophe-schemas/public/js/user.js
@@ -1578,10 +1578,10 @@ apos.define('apostrophe-schemas', {
           allowEmpty: true
         };
 
-        field.options = _.merge(defaults, options || {});
+        options = _.merge(defaults, options || {});
         // populate color last and outside of merge
-        field.options.color = data[name];
-        apos.ui.enhanceColorpicker($field, data[name], field.options);
+        options.color = data[name];
+        apos.ui.enhanceColorpicker($field, data[name], options);
         return setImmediate(callback);
       },
       convert: function (data, name, $field, $el, field, callback) {

--- a/lib/modules/apostrophe-tasks/index.js
+++ b/lib/modules/apostrophe-tasks/index.js
@@ -7,10 +7,6 @@
 // Apostrophe is fully initialized before your task is run, except that it does
 // not listen for connections. So you may access all of its features in your task.
 
-// Direct use of `console` makes sense here because
-// we're implementing an interaction at the CLI.
-// -Tom
-
 /* eslint-disable no-console */
 
 var _ = require('@sailshq/lodash');

--- a/lib/modules/apostrophe-templates/index.js
+++ b/lib/modules/apostrophe-templates/index.js
@@ -77,10 +77,10 @@ module.exports = {
     };
 
     // The use of this method is restricted to core modules
-    // and should only be used for apos.area, apos.singleton,
+    // and should only be used for `apos.area`, `apos.singleton`,
     // and anything we later decide is at least that important.
     // Everything else should be namespaced at all times,
-    // at least under its module alias. -Tom
+    // at least under its module alias.
 
     self.addShortcutHelper = function(name, value) {
       self.shortcutHelpers[name] = value;

--- a/lib/modules/apostrophe-ui/public/js/context.js
+++ b/lib/modules/apostrophe-ui/public/js/context.js
@@ -31,7 +31,7 @@ apos.define('apostrophe-context', {
     // Your subclass must set self.$el to use this method.
     //
     // The word "object" refers to "the object of the sentence."
-    // It is a STRING, not a javascript object. -Tom and Joel
+    // It is a *string*, not a javascript object.
 
     self.link = function(verb, object, fn) {
       if (arguments.length === 2) {

--- a/lib/modules/apostrophe-utils/lib/api.js
+++ b/lib/modules/apostrophe-utils/lib/api.js
@@ -326,14 +326,19 @@ module.exports = function(self, options) {
   // (Array.isArray returns true). Otherwise all objects with
   // a length property would be treated as arrays, which is
   // an unrealistic restriction on apostrophe doc schemas.
+  //
+  // If o itself is a string, boolean or other scalar type it is returned
+  // as-is.
 
   self.clonePermanent = function(o, keepScalars) {
     var c;
     var isArray = Array.isArray(o);
     if (isArray) {
       c = [];
-    } else {
+    } else if ((o != null) && ((typeof o) === 'object')) {
       c = {};
+    } else {
+      return o;
     }
 
     function iterator(val, key) {

--- a/lib/modules/apostrophe-utils/lib/api.js
+++ b/lib/modules/apostrophe-utils/lib/api.js
@@ -327,8 +327,8 @@ module.exports = function(self, options) {
   // a length property would be treated as arrays, which is
   // an unrealistic restriction on apostrophe doc schemas.
   //
-  // If o itself is a string, boolean or other scalar type it is returned
-  // as-is.
+  // If `o` (usually the object) itself is a string, boolean or other scalar
+  // type it is returned as-is.
 
   self.clonePermanent = function(o, keepScalars) {
     var c;

--- a/lib/modules/apostrophe-versions/lib/api.js
+++ b/lib/modules/apostrophe-versions/lib/api.js
@@ -58,7 +58,7 @@ module.exports = function(self, options) {
   // removed. Thus versions become more sparse as we move back
   // through time. However if two consecutive versions have
   // different authors we never discard them because
-  // we don't want to create a false audit trail. -Tom
+  // we don't want to create a false audit trail.
 
   self.pruneOldVersions = function(doc, callback) {
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "2.107.0",
+  "version": "2.107.1",
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe",
-  "version": "2.107.1",
+  "version": "2.108.0",
   "description": "The Apostrophe Content Management System.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "express-session": "^1.17.0",
     "glob": "^5.0.15",
     "he": "^0.5.0",
-    "heic-to-jpeg-middleware": "^1.0.2",
+    "heic-to-jpeg-middleware": "^2.0.0",
     "html-to-plaintext": "^0.1.1",
     "html-to-text": "^5.1.1",
     "i18n": "^0.8.6",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "express-session": "^1.17.0",
     "glob": "^5.0.15",
     "he": "^0.5.0",
+    "heic-to-jpeg-middleware": "^1.0.2",
     "html-to-plaintext": "^0.1.1",
     "html-to-text": "^5.1.1",
     "i18n": "^0.8.6",


### PR DESCRIPTION
This PR adds the functionality requested on `https://github.com/apostrophecms/apostrophe/issues/1349` to allow iPhone and iPad users to upload images on `HEIC and HEIF` format, through the express middleware https://www.npmjs.com/package/heic-to-jpeg-middleware